### PR TITLE
PI-707: Fixing bug where === true was failing because Magento ORM sto…

### DIFF
--- a/Backend/CacheTags.php
+++ b/Backend/CacheTags.php
@@ -101,7 +101,7 @@ class CacheTags
      * @param $tags
      */
     public function purgeCacheTags(array $tags) {
-        if (!empty($tags) && $this->dataStore->get(\CF\API\Plugin::SETTING_PLUGIN_SPECIFIC_CACHE_TAG) === true) {
+        if (!empty($tags) && $this->dataStore->get(\CF\API\Plugin::SETTING_PLUGIN_SPECIFIC_CACHE_TAG)) {
             $tags = $this->hashCacheTags($tags);
             $this->clientAPI->zonePurgeCacheByTags($tags);
         }

--- a/Backend/MagentoAPI.php
+++ b/Backend/MagentoAPI.php
@@ -66,6 +66,7 @@ class MagentoAPI implements IntegrationAPIInterface
     /**
      * @param $key
      * @param $value
+     * @return bool
      */
     public function setValue($key, $value) {
         $keyValueModel = $this->keyValueFactory->create();
@@ -81,6 +82,7 @@ class MagentoAPI implements IntegrationAPIInterface
             $keyValueModel->setData(InstallSchema::CLOUDFLARE_DATA_TABLE_VALUE_COLUMN, $value);
             $keyValueModel->save();
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
…res true as 1.

@thellimist ironically enough the Magento ORM stores `true` as 1 in the database so it failed the `===` check and I had to switch it anyway haha.