### PR TITLE
PI-1074: Magento 2.1 DI can't inject PHP classes from non Magento mod…

### DIFF
--- a/Controller/Adminhtml/Plugin/Proxy.php
+++ b/Controller/Adminhtml/Plugin/Proxy.php
@@ -41,7 +41,6 @@ class Proxy extends AbstractAction
      * @param JsonFactory $resultJsonFactory
      * @param LoggerInterface $logger
      * @param Backend\MagentoAPI|MagentoAPI $magentoAPI
-     * @param RequestRouter $requestRouter
      */
     public function __construct(
         Context $context,
@@ -49,20 +48,19 @@ class Proxy extends AbstractAction
         MagentoIntegration $integrationContext,
         JsonFactory $resultJsonFactory,
         LoggerInterface $logger,
-        MagentoAPI $magentoAPI,
-        RequestRouter $requestRouter,
-        ClientAPI $clientAPI,
-        Plugin $pluginAPI
+        MagentoAPI $magentoAPI
     ) {
         $this->dataStore = $dataStore;
         $this->integrationContext = $integrationContext;
         $this->logger = $logger;
         $this->magentoAPI = $magentoAPI;
         $this->resultJsonFactory = $resultJsonFactory;
-        $this->requestRouter = $requestRouter;
-        $this->clientAPI = $clientAPI;
-        $this->pluginAPI = $pluginAPI;
 
+        //PI-1074 - new is bad but a necessary work around here.
+        $this->clientAPI = new ClientAPI($this->integrationContext);
+        $this->pluginAPI = new Plugin($this->integrationContext);
+
+        $this->requestRouter = new RequestRouter($this->integrationContext);
         $this->requestRouter->addRouter($this->clientAPI, ClientRoutes::$routes);
         $this->requestRouter->addRouter($this->pluginAPI, PluginRoutes::getRoutes(\CF\API\PluginRoutes::$routes));
 
@@ -132,5 +130,29 @@ class Proxy extends AbstractAction
         $parameters[self::FORM_KEY] = $token;
         $request->setParams($parameters);
         return $request;
+    }
+
+    /**
+     * @param RequestRouter $requestRouter
+     */
+    public function setRequestRouter(RequestRouter $requestRouter)
+    {
+        $this->requestRouter = $requestRouter;
+    }
+
+    /**
+     * @param ClientAPI $clientAPI
+     */
+    public function setClientAPI(ClientAPI $clientAPI)
+    {
+        $this->clientAPI = $clientAPI;
+    }
+
+    /**
+     * @param Plugin $pluginAPI
+     */
+    public function setPluginAPI(Plugin $pluginAPI)
+    {
+        $this->pluginAPI = $pluginAPI;
     }
 }

--- a/Test/Unit/Controller/Adminhtml/Plugin/ProxyTest.php
+++ b/Test/Unit/Controller/Adminhtml/Plugin/ProxyTest.php
@@ -24,9 +24,13 @@ class ProxyTest extends \PHPUnit_Framework_TestCase
         $this->mockDataStore = $this->getMockBuilder('\CloudFlare\Plugin\Backend\DataStore')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->mockHttpClient = $this->getMockBuilder('\CloudFlare\Plugin\Backend\MagentoHttpClient')
+            ->disableOriginalConstructor()
+            ->getMock();
         $this->mockIntegrationContext = $this->getMockBuilder('\CloudFlare\Plugin\Backend\MagentoIntegration')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->mockIntegrationContext->method('getHttpClient')->willReturn($this->mockHttpClient);
         $this->mockResultJsonFactory = $this->getMockBuilder('\Magento\Framework\Controller\Result\JsonFactory')
             ->disableOriginalConstructor()
             ->getMock();
@@ -52,11 +56,12 @@ class ProxyTest extends \PHPUnit_Framework_TestCase
             $this->mockIntegrationContext,
             $this->mockResultJsonFactory,
             $this->mockLogger,
-            $this->mockMagentoAPI,
-            $this->mockRequestRouter,
-            $this->mockClientAPI,
-            $this->mockPluginAPI
+            $this->mockMagentoAPI
         );
+
+        $this->proxy->setRequestRouter($this->mockRequestRouter);
+        $this->proxy->setClientAPI($this->mockClientAPI);
+        $this->proxy->setPluginAPI($this->mockPluginAPI);
     }
 
     public function testProcessUrlKeysCallsSetJsonFormTokenOnMagentoRequest()

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -30,6 +30,8 @@
         </arguments>
     </type>
     <preference for="CF\Integration\IntegrationInterface" type="CloudFlare\Plugin\Backend\MagentoIntegration" />
+    <!-- PI-1074 - revert when Magnento 2.2 is released -->
+    <!--
     <type name="CloudFlare\Plugin\Backend\ClientAPI">
         <arguments>
             <argument name="integration" xsi:type="object">\CloudFlare\Plugin\Backend\MagentoIntegration</argument>
@@ -44,7 +46,7 @@
         <arguments>
             <argument name="integrationContext" xsi:type="object">\CloudFlare\Plugin\Backend\MagentoIntegration</argument>
         </arguments>
-    </type>
+    </type> -->
     <!-- Restore original visitor IP from CloudFlare header -->
     <type name="Magento\Framework\HTTP\PhpEnvironment\RemoteAddress">
         <arguments>


### PR DESCRIPTION
In Magento 2.1 running:
```
composer require cloudflare/cloudflare-magento 
bin/magento setup:upgrade 
bin/magento deploy:mode:set production 
bin/magento indexer:reindex
```
results in 
```
Fatal error: Uncaught TypeError: Argument 1 passed to CF\Router\RequestRouter::__construct() must implement interface CF\Integration\IntegrationInterface, instance of Magento\Framework\ObjectManager\ObjectManager given
```

This is because Magento 2.1 DI isn't able to inject PHP classes from composer packages that aren't Magento modules.  This is fixed in Magento 2.2.  The workaround is to `new` up the dependencies for these classes manually, bypassing `di.xml`.