### PR TITLE
PI-1257 add support for PHP version 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
   "require": {
-    "php": "~5.6.0|~7.0.0",
+    "php": "~5.6.0|~7.0",
     "cloudflare/cloudflare-plugin-backend": "^2.1"
   },
   "type": "magento2-module",


### PR DESCRIPTION
https://github.com/cloudflare/Cloudflare-Magento/issues/67

Magento 2.2.0 [supports](http://devdocs.magento.com/guides/v2.2/release-notes/ReleaseNotes2.2.0CE.html) PHP 7.1 however it may not support newer versions of PHP. If a newer version of PHP breaks, we can add a limit. Until then there is no limit for PHP 7.x




